### PR TITLE
Support setting a custom ZFS volume size for snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/mistifyio/go-zfs/v3 v3.0.1
 	github.com/pelletier/go-toml/v2 v2.2.3
+	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/sys v0.26.0
 	google.golang.org/grpc v1.67.1
 )
@@ -33,7 +34,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/net v0.30.0 // indirect


### PR DESCRIPTION
## Description

Support setting a custom ZFS volume size for snapshots.

The volume size can be configured by appending the label `containerd.io/snapshot/zvol/size` with the volume size in bytes as the value.

The value can not be smaller than the configured default volume size and has to be larger or equal to the volume size of its parent.

The helper function `WithVolumeSize` can be used to set the label.